### PR TITLE
Add testIncludes config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following options can be set in `.arcconfig`:
 | `unit.mocha.bin.istanbul`       | `"./node_modules/istanbul/lib/cli.js"` | Path used to invoke `istanbul`.                               |
 | `unit.mocha.coverage.reportdir` | `"./coverage"`                         | Path to the directory where `istanbul` should output reports. |
 | `unit.mocha.coverage.exclude`   | `null`                                 | An array of paths to exclude from coverage reports.           |
+| `unit.mocha.include`            | `null`                                 | An array of paths to include for the mocha tests.             |
 
 Example values for `unit.mocha.coverage.exclude`:
 ```json

--- a/src/engine/MochaEngine.php
+++ b/src/engine/MochaEngine.php
@@ -10,6 +10,7 @@ final class MochaEngine extends ArcanistUnitTestEngine {
     private $istanbulBin;
     private $coverReportDir;
     private $coverExcludes;
+    private $testIncludes;
 
     /**
      * Determine which executables and test paths to use.
@@ -41,6 +42,10 @@ final class MochaEngine extends ArcanistUnitTestEngine {
 
         $this->coverExcludes = $config->getConfigFromAnySource(
             'unit.mocha.coverage.exclude');
+
+        $this->testIncludes = $config->getConfigFromAnySource(
+            'unit.mocha.test.include',
+            '');
 
         // Make sure required binaries are available
         $binaries = array($this->mochaBin, $this->_mochaBin,
@@ -112,16 +117,26 @@ final class MochaEngine extends ArcanistUnitTestEngine {
             }
         }
 
+        // Create test include options list
+        $include_opts = '';
+        if ($this->testIncludes != null) {
+            foreach ($this->testIncludes as $include_glob) {
+                $include_opts .= ' -x ' . escapeshellarg($include_glob);
+            }
+        }
+        
         return new ExecFuture('%C cover %s ' .
                               '--report clover ' .
                               '--dir %s ' .
                               '--default-excludes ' .
                               '--include-all-sources ' .
-                              '%C',
+                              '%C ' .
+                              '%C ',
                               $this->istanbulBin,
                               $this->_mochaBin,
                               $this->coverReportDir,
-                              $exclude_opts);
+                              $exclude_opts,
+                              $include_opts);
     }
 
     protected function parseTestResults($xunit_tmp, $cover_xml_path) {


### PR DESCRIPTION
Add config option to specify the test files to include to validate the coverage.

In our use case, we only want to run the unit test, but not the heavyweight integration tests on pre-commit.